### PR TITLE
Add test for kuka_kr6 using random robot poses.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,3 +61,12 @@ endif()
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
+
+# add a ros node to run the kuka_kr6_test
+# I don't know a better way to get a clean test output in the terminal
+add_executable(${PROJECT_NAME}_kuka_kr6_test test/kuka_kr6_test.cpp)
+set_target_properties(${PROJECT_NAME}_kuka_kr6_test PROPERTIES OUTPUT_NAME kuka_kr6_test PREFIX "")
+target_link_libraries(${PROJECT_NAME}_kuka_kr6_test
+ gtest
+ ${catkin_LIBRARIES}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,14 +59,9 @@ if(TARGET ${PROJECT_NAME}-test)
   target_compile_definitions(${PROJECT_NAME}-test PUBLIC -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -DIKFAST_HAS_LIBRARY)
 endif()
 
+catkin_add_gtest(${PROJECT_NAME}-test-kuka
+  test/kuka_kr6_test.cpp
+)
+
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
-
-# add a ros node to run the kuka_kr6_test
-# I don't know a better way to get a clean test output in the terminal
-add_executable(${PROJECT_NAME}_kuka_kr6_test test/kuka_kr6_test.cpp)
-set_target_properties(${PROJECT_NAME}_kuka_kr6_test PROPERTIES OUTPUT_NAME kuka_kr6_test PREFIX "")
-target_link_libraries(${PROJECT_NAME}_kuka_kr6_test
- gtest
- ${catkin_LIBRARIES}
-)

--- a/include/opw_kinematics/opw_parameters_examples.h
+++ b/include/opw_kinematics/opw_parameters_examples.h
@@ -43,7 +43,6 @@ Parameters<T> makeFanucR2000iB_200R()
 }
 
 template <typename T>
-__attribute__((deprecated("UN-TESTED")))
 Parameters<T> makeKukaKR6_R700_sixx()
 {
   Parameters<T> p;
@@ -55,8 +54,7 @@ Parameters<T> makeKukaKR6_R700_sixx()
   p.c3 = T(0.365);
   p.c4 = T(0.080);
 
-  // WARNING: This is a guess! I don't know the offets.
-  p.offsets[2] = -M_PI / 2.0;
+  p.offsets[1] = -M_PI / 2.0;
 
   return p;
 }

--- a/test/kuka_kr6_test.cpp
+++ b/test/kuka_kr6_test.cpp
@@ -3,17 +3,17 @@
 #include <random>
 
 #include "opw_kinematics/opw_kinematics.h"
-#include "opw_kinematics/opw_parameters_examples.h" // for makeIrb2400_10<double>()
-#include "opw_kinematics/opw_utilities.h"           // for optional checking
+#include "opw_kinematics/opw_parameters_examples.h"  // for makeIrb2400_10<double>()
+#include "opw_kinematics/opw_utilities.h"            // for optional checking
 
 const double TOLERANCE_DOUBLE = 1e-10;
-const float  TOLERANCE_FLOAT  = 1e-5;
+const float TOLERANCE_FLOAT = 1e-5;
 
 template <typename T>
 using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
 
 template <typename T>
-void comparePoses(const Transform<T> & Ta, const Transform<T> & Tb, double tolerance)
+void comparePoses(const Transform<T>& Ta, const Transform<T>& Tb, double tolerance)
 {
   using Matrix = Eigen::Matrix<T, 3, 3>;
   using Vector = Eigen::Matrix<T, 3, 1>;
@@ -34,10 +34,10 @@ void comparePoses(const Transform<T> & Ta, const Transform<T> & Tb, double toler
 }
 
 template <typename T>
-void getRandomJointValues(T * q)
+void getRandomJointValues(T* q)
 {
-  static std::default_random_engine en{42}; // random engine
-  static std::uniform_real_distribution<T> rg{-M_PI, M_PI}; // random generator
+  static std::default_random_engine en{ 42 };                  // random engine
+  static std::uniform_real_distribution<T> rg{ -M_PI, M_PI };  // random generator
 
   q[0] = rg(en);
   q[1] = rg(en);
@@ -109,7 +109,7 @@ TEST(kuka_kr6, random_reachable_poses_float)
   }
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/kuka_kr6_test.cpp
+++ b/test/kuka_kr6_test.cpp
@@ -47,7 +47,7 @@ void getRandomJointValues(T * q)
 TEST(kuka_kr6, random_reachable_poses_double)
 {
   const int number_of_tests = 10;
-  const auto abb2400 = opw_kinematics::makeIrb2400_10<double>();
+  const auto kukaKR6_R700_sixx = opw_kinematics::makeKukaKR6_R700_sixx<double>();
 
   Eigen::Affine3d pose;
   double q_rand[6];
@@ -56,11 +56,11 @@ TEST(kuka_kr6, random_reachable_poses_double)
   {
     // create a reachable pose based on a random robot position
     getRandomJointValues(q_rand);
-    pose = opw_kinematics::forward(abb2400, q_rand);
+    pose = opw_kinematics::forward(kukaKR6_R700_sixx, q_rand);
 
     // Solve Inverse kinematics
     std::array<double, 6 * 8> sols;
-    opw_kinematics::inverse(abb2400, pose, sols.data());
+    opw_kinematics::inverse(kukaKR6_R700_sixx, pose, sols.data());
 
     // check all valid solutions using forward kinematics
     for (int i = 0; i < 8; ++i)
@@ -68,7 +68,7 @@ TEST(kuka_kr6, random_reachable_poses_double)
       if (opw_kinematics::isValid(&sols[6 * i]))
       {
         // Forward kinematics of a solution should result in the same pose
-        Eigen::Affine3d forward_pose = opw_kinematics::forward(abb2400, &sols[6 * i]);
+        Eigen::Affine3d forward_pose = opw_kinematics::forward(kukaKR6_R700_sixx, &sols[6 * i]);
         comparePoses(forward_pose, pose);
       }
     }
@@ -78,7 +78,7 @@ TEST(kuka_kr6, random_reachable_poses_double)
 TEST(kuka_kr6, random_reachable_poses_float)
 {
   const int number_of_tests = 10;
-  const auto abb2400 = opw_kinematics::makeIrb2400_10<float>();
+  const auto kukaKR6_R700_sixx = opw_kinematics::makeKukaKR6_R700_sixx<float>();
 
   Eigen::Affine3f pose;
   float q_rand[6];
@@ -87,11 +87,11 @@ TEST(kuka_kr6, random_reachable_poses_float)
   {
     // create a pose based on a random robot position
     getRandomJointValues(q_rand);
-    pose = opw_kinematics::forward(abb2400, q_rand);
+    pose = opw_kinematics::forward(kukaKR6_R700_sixx, q_rand);
 
     // Inverse kinematics
     std::array<float, 6 * 8> sols; // You could also use a std::vector or c-array of the appropriate size (6*8)
-    opw_kinematics::inverse(abb2400, pose, sols.data());
+    opw_kinematics::inverse(kukaKR6_R700_sixx, pose, sols.data());
 
     // check all valid solutions using forward kinematics
     for (int i = 0; i < 8; ++i)
@@ -99,7 +99,7 @@ TEST(kuka_kr6, random_reachable_poses_float)
       if (opw_kinematics::isValid(&sols[6 * i]))
       {
         // Forward kinematics
-        Eigen::Affine3f forward_pose = opw_kinematics::forward(abb2400, &sols[6 * i]);
+        Eigen::Affine3f forward_pose = opw_kinematics::forward(kukaKR6_R700_sixx, &sols[6 * i]);
         comparePoses(forward_pose, pose);
       }
     }

--- a/test/kuka_kr6_test.cpp
+++ b/test/kuka_kr6_test.cpp
@@ -1,0 +1,113 @@
+#include <array>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "opw_kinematics/opw_kinematics.h"
+#include "opw_kinematics/opw_parameters_examples.h" // for makeIrb2400_10<double>()
+#include "opw_kinematics/opw_utilities.h"           // for optional checking
+
+template <typename T>
+using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
+
+template <typename T>
+void comparePoses(const Transform<T> & Ta, const Transform<T> & Tb)
+{
+  using Matrix = Eigen::Matrix<T, 3, 3>;
+  using Vector = Eigen::Matrix<T, 3, 1>;
+
+  Matrix Ra = Ta.rotation(), Rb = Tb.rotation();
+  for (int i = 0; i < Ra.rows(); ++i)
+  {
+    for (int j = 0; j < Ra.cols(); ++j)
+    {
+      EXPECT_NEAR(Ra(i, j), Rb(i, j), 1e-6);
+    }
+  }
+
+  Vector pa = Ta.translation(), pb = Tb.translation();
+  EXPECT_NEAR(pa[0], pb[0], 1e-6);
+  EXPECT_NEAR(pa[1], pb[1], 1e-6);
+  EXPECT_NEAR(pa[2], pb[2], 1e-6);
+}
+
+template <typename T>
+void getRandomJointValues(T * q)
+{
+  static std::default_random_engine en{42}; // random engine
+  static std::uniform_real_distribution<T> rg{-M_PI, M_PI}; // random generator
+
+  q[0] = rg(en);
+  q[1] = rg(en);
+  q[2] = rg(en);
+  q[3] = rg(en);
+  q[4] = rg(en);
+  q[5] = rg(en);
+}
+
+TEST(kuka_kr6, random_reachable_poses_double)
+{
+  const int number_of_tests = 10;
+  const auto abb2400 = opw_kinematics::makeIrb2400_10<double>();
+
+  Eigen::Affine3d pose;
+  double q_rand[6];
+
+  for (int j = 0; j < number_of_tests; ++j)
+  {
+    // create a reachable pose based on a random robot position
+    getRandomJointValues(q_rand);
+    pose = opw_kinematics::forward(abb2400, q_rand);
+
+    // Solve Inverse kinematics
+    std::array<double, 6 * 8> sols;
+    opw_kinematics::inverse(abb2400, pose, sols.data());
+
+    // check all valid solutions using forward kinematics
+    for (int i = 0; i < 8; ++i)
+    {
+      if (opw_kinematics::isValid(&sols[6 * i]))
+      {
+        // Forward kinematics of a solution should result in the same pose
+        Eigen::Affine3d forward_pose = opw_kinematics::forward(abb2400, &sols[6 * i]);
+        comparePoses(forward_pose, pose);
+      }
+    }
+  }
+}
+
+TEST(kuka_kr6, random_reachable_poses_float)
+{
+  const int number_of_tests = 10;
+  const auto abb2400 = opw_kinematics::makeIrb2400_10<float>();
+
+  Eigen::Affine3f pose;
+  float q_rand[6];
+
+  for (int j = 0; j < number_of_tests; ++j)
+  {
+    // create a pose based on a random robot position
+    getRandomJointValues(q_rand);
+    pose = opw_kinematics::forward(abb2400, q_rand);
+
+    // Inverse kinematics
+    std::array<float, 6 * 8> sols; // You could also use a std::vector or c-array of the appropriate size (6*8)
+    opw_kinematics::inverse(abb2400, pose, sols.data());
+
+    // check all valid solutions using forward kinematics
+    for (int i = 0; i < 8; ++i)
+    {
+      if (opw_kinematics::isValid(&sols[6 * i]))
+      {
+        // Forward kinematics
+        Eigen::Affine3f forward_pose = opw_kinematics::forward(abb2400, &sols[6 * i]);
+        comparePoses(forward_pose, pose);
+      }
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I added a test that can be used for any robot, but this implementation only tests the [kuka kr6 r700 robot](https://github.com/Jmeyer1292/opw_kinematics/blob/af1903802f07d75a78717e2436153cf86277160e/include/opw_kinematics/opw_parameters_examples.h#L47).

The test uses random joint values to create a reachable pose. 
Then it solves the inverse kinematics for this pose.
Finally, it check's if the forward kinematics of all solutions result in the same pose. (Only for valid joint solutions.)

I wrote the same test for types `float` and `double`. This is probably superfluous, but the functionallity was there, so I though I might as well test it.

**Important note:** I added the test as a ROS node to the CMakeList.txt because I do not know how to do it properly without burying the test results in a lot of verbose output.

Feel free to suggest how I can improve it :)