### PR TITLE
Add joint sign corrections to parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,5 +59,9 @@ if(TARGET ${PROJECT_NAME}-test)
   target_compile_definitions(${PROJECT_NAME}-test PUBLIC -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -DIKFAST_HAS_LIBRARY)
 endif()
 
+catkin_add_gtest(${PROJECT_NAME}-test-sign-corrections
+  test/sign_corrections_tests.cpp
+)
+
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/include/opw_kinematics/opw_io.h
+++ b/include/opw_kinematics/opw_io.h
@@ -8,17 +8,27 @@ namespace opw_kinematics
 {
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Parameters<T>& params)
+std::ostream &operator<<(std::ostream &os, const Parameters<T> &params)
 {
-  os << params.a1 << " " << params.a2 << " " << params.b << " " <<
-        params.c1 << " " << params.c2 << " " << params.c3 << " " <<
-        params.c4 << "\n";
-  os << "Offsets = [" << params.offsets[0] << " " << params.offsets[1] <<
-        " " << params.offsets[2] << " " << params.offsets[3] << " " <<
-        params.offsets[4] << " " << params.offsets[5] << "]\n";
+  os << "Distances: [" << params.a1 << " "
+     << params.a2 << " "
+     << params.b << " " << params.c1 << " "
+     << params.c2 << " " << params.c3 << " "
+     << params.c4 << "]\n";
+  os << "Offsets = [";
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    os << params.offsets[i] << " ";
+  }
+  os << "]\nSign_corrections = [";
+  for (std::size_t i = 0; i < 6; ++i)
+  {
+    os << params.sign_corrections[i] << " ";
+  }
+  os << "]";
   return os;
 }
 
-}
+} // namespace opw_kinematics
 
 #endif // OPW_IO_H

--- a/include/opw_kinematics/opw_io.h
+++ b/include/opw_kinematics/opw_io.h
@@ -8,7 +8,7 @@ namespace opw_kinematics
 {
 
 template <typename T>
-std::ostream &operator<<(std::ostream &os, const Parameters<T> &params)
+std::ostream& operator<<(std::ostream& os, const Parameters<T>& params)
 {
   os << "Distances: [" << params.a1 << " "
      << params.a2 << " "

--- a/include/opw_kinematics/opw_kinematics_impl.h
+++ b/include/opw_kinematics/opw_kinematics_impl.h
@@ -129,61 +129,61 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
   T theta6_vii = theta6_iii - M_PI;
   T theta6_viii = theta6_iv - M_PI;
 
-  out[6 * 0 + 0] = theta1_i + params.offsets[0];
-  out[6 * 0 + 1] = theta2_i + params.offsets[1];
-  out[6 * 0 + 2] = theta3_i + params.offsets[2];
-  out[6 * 0 + 3] = theta4_i + params.offsets[3];
-  out[6 * 0 + 4] = theta5_i + params.offsets[4];
-  out[6 * 0 + 5] = theta6_i + params.offsets[5];
+  out[6 * 0 + 0] = (theta1_i + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 0 + 1] = (theta2_i + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 0 + 2] = (theta3_i + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 0 + 3] = (theta4_i + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 0 + 4] = (theta5_i + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 0 + 5] = (theta6_i + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 1 + 0] = theta1_i + params.offsets[0];
-  out[6 * 1 + 1] = theta2_ii + params.offsets[1];
-  out[6 * 1 + 2] = theta3_ii + params.offsets[2];
-  out[6 * 1 + 3] = theta4_ii + params.offsets[3];
-  out[6 * 1 + 4] = theta5_ii + params.offsets[4];
-  out[6 * 1 + 5] = theta6_ii + params.offsets[5];
+  out[6 * 1 + 0] = (theta1_i  + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 1 + 1] = (theta2_ii + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 1 + 2] = (theta3_ii + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 1 + 3] = (theta4_ii + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 1 + 4] = (theta5_ii + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 1 + 5] = (theta6_ii + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 2 + 0] = theta1_ii + params.offsets[0];
-  out[6 * 2 + 1] = theta2_iii + params.offsets[1];
-  out[6 * 2 + 2] = theta3_iii + params.offsets[2];
-  out[6 * 2 + 3] = theta4_iii + params.offsets[3];
-  out[6 * 2 + 4] = theta5_iii + params.offsets[4];
-  out[6 * 2 + 5] = theta6_iii + params.offsets[5];
+  out[6 * 2 + 0] = (theta1_ii  + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 2 + 1] = (theta2_iii + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 2 + 2] = (theta3_iii + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 2 + 3] = (theta4_iii + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 2 + 4] = (theta5_iii + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 2 + 5] = (theta6_iii + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 3 + 0] = theta1_ii + params.offsets[0];
-  out[6 * 3 + 1] = theta2_iv + params.offsets[1];
-  out[6 * 3 + 2] = theta3_iv + params.offsets[2];
-  out[6 * 3 + 3] = theta4_iv + params.offsets[3];
-  out[6 * 3 + 4] = theta5_iv + params.offsets[4];
-  out[6 * 3 + 5] = theta6_iv + params.offsets[5];
+  out[6 * 3 + 0] = (theta1_ii + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 3 + 1] = (theta2_iv + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 3 + 2] = (theta3_iv + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 3 + 3] = (theta4_iv + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 3 + 4] = (theta5_iv + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 3 + 5] = (theta6_iv + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 4 + 0] = theta1_i + params.offsets[0];
-  out[6 * 4 + 1] = theta2_i + params.offsets[1];
-  out[6 * 4 + 2] = theta3_i + params.offsets[2];
-  out[6 * 4 + 3] = theta4_v + params.offsets[3];
-  out[6 * 4 + 4] = theta5_v + params.offsets[4];
-  out[6 * 4 + 5] = theta6_v + params.offsets[5];
+  out[6 * 4 + 0] = (theta1_i + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 4 + 1] = (theta2_i + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 4 + 2] = (theta3_i + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 4 + 3] = (theta4_v + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 4 + 4] = (theta5_v + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 4 + 5] = (theta6_v + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 5 + 0] = theta1_i + params.offsets[0];
-  out[6 * 5 + 1] = theta2_ii + params.offsets[1];
-  out[6 * 5 + 2] = theta3_ii + params.offsets[2];
-  out[6 * 5 + 3] = theta4_vi + params.offsets[3];
-  out[6 * 5 + 4] = theta5_vi + params.offsets[4];
-  out[6 * 5 + 5] = theta6_vi + params.offsets[5];
+  out[6 * 5 + 0] = (theta1_i  + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 5 + 1] = (theta2_ii + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 5 + 2] = (theta3_ii + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 5 + 3] = (theta4_vi + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 5 + 4] = (theta5_vi + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 5 + 5] = (theta6_vi + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 6 + 0] = theta1_ii + params.offsets[0];
-  out[6 * 6 + 1] = theta2_iii + params.offsets[1];
-  out[6 * 6 + 2] = theta3_iii + params.offsets[2];
-  out[6 * 6 + 3] = theta4_vii + params.offsets[3];
-  out[6 * 6 + 4] = theta5_vii + params.offsets[4];
-  out[6 * 6 + 5] = theta6_vii + params.offsets[5];
+  out[6 * 6 + 0] = (theta1_ii  + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 6 + 1] = (theta2_iii + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 6 + 2] = (theta3_iii + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 6 + 3] = (theta4_vii + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 6 + 4] = (theta5_vii + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 6 + 5] = (theta6_vii + params.offsets[5]) * params.sign_corrections[5];
 
-  out[6 * 7 + 0] = theta1_ii + params.offsets[0];
-  out[6 * 7 + 1] = theta2_iv + params.offsets[1];
-  out[6 * 7 + 2] = theta3_iv + params.offsets[2];
-  out[6 * 7 + 3] = theta4_viii + params.offsets[3];
-  out[6 * 7 + 4] = theta5_viii + params.offsets[4];
-  out[6 * 7 + 5] = theta6_viii + params.offsets[5];
+  out[6 * 7 + 0] = (theta1_ii   + params.offsets[0]) * params.sign_corrections[0];
+  out[6 * 7 + 1] = (theta2_iv   + params.offsets[1]) * params.sign_corrections[1];
+  out[6 * 7 + 2] = (theta3_iv   + params.offsets[2]) * params.sign_corrections[2];
+  out[6 * 7 + 3] = (theta4_viii + params.offsets[3]) * params.sign_corrections[3];
+  out[6 * 7 + 4] = (theta5_viii + params.offsets[4]) * params.sign_corrections[4];
+  out[6 * 7 + 5] = (theta6_viii + params.offsets[5]) * params.sign_corrections[5];
 }
 
 template <typename T>
@@ -193,12 +193,12 @@ Transform<T> forward(const Parameters<T>& p, const T* qs)
   using Vector = Eigen::Matrix<T, 3, 1>;
 
   T q[6];
-  q[0] = qs[0] - p.offsets[0];
-  q[1] = qs[1] - p.offsets[1];
-  q[2] = qs[2] - p.offsets[2];
-  q[3] = qs[3] - p.offsets[3];
-  q[4] = qs[4] - p.offsets[4];
-  q[5] = qs[5] - p.offsets[5];
+  q[0] = qs[0] * p.sign_corrections[0] - p.offsets[0];
+  q[1] = qs[1] * p.sign_corrections[1] - p.offsets[1];
+  q[2] = qs[2] * p.sign_corrections[2] - p.offsets[2];
+  q[3] = qs[3] * p.sign_corrections[3] - p.offsets[3];
+  q[4] = qs[4] * p.sign_corrections[4] - p.offsets[4];
+  q[5] = qs[5] * p.sign_corrections[5] - p.offsets[5];
 
   T psi3 = atan2(p.a2, p.c3);
   T k = sqrt(p.a2 * p.a2 + p.c3 * p.c3);

--- a/include/opw_kinematics/opw_parameters.h
+++ b/include/opw_kinematics/opw_parameters.h
@@ -14,10 +14,12 @@ struct Parameters
 
   T a1, a2, b, c1, c2, c3, c4;
   T offsets[6];
+  short int sign_corrections[6];
 
   Parameters()
     : a1{0}, a2{0}, b{0}, c1{0}, c2{0}, c3{0}, c4{4},
-      offsets{0, 0, 0, 0, 0, 0}
+      offsets{0, 0, 0, 0, 0, 0},
+      sign_corrections{1, 1, 1, 1, 1, 1}
   {}
 };
 

--- a/include/opw_kinematics/opw_parameters_examples.h
+++ b/include/opw_kinematics/opw_parameters_examples.h
@@ -43,7 +43,6 @@ Parameters<T> makeFanucR2000iB_200R()
 }
 
 template <typename T>
-__attribute__((deprecated("UN-TESTED")))
 Parameters<T> makeKukaKR6_R700_sixx()
 {
   Parameters<T> p;
@@ -55,8 +54,10 @@ Parameters<T> makeKukaKR6_R700_sixx()
   p.c3 = T(0.365);
   p.c4 = T(0.080);
 
-  // WARNING: This is a guess! I don't know the offets.
-  p.offsets[2] = -M_PI / 2.0;
+  p.offsets[1] = -M_PI / 2.0;
+  p.sign_corrections[0] = -1;
+  p.sign_corrections[3] = -1;
+  p.sign_corrections[5] = -1;
 
   return p;
 }

--- a/test/sign_corrections_tests.cpp
+++ b/test/sign_corrections_tests.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <Eigen/Dense>
+
+#include "opw_kinematics/opw_kinematics.h"
+#include "opw_kinematics/opw_parameters_examples.h"
+
+const double TOLERANCE = 1e-6; // absolute tolerance for EXPECT_NEAR checks
+
+template <typename T>
+using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
+
+/** @brief Compare every element of two eigen affine3 poses.
+ */
+template <typename T>
+void comparePoses(const Transform<T> & Ta, const Transform<T> & Tb)
+{
+  using Matrix = Eigen::Matrix<T, 3, 3>;
+  using Vector = Eigen::Matrix<T, 3, 1>;
+
+  Matrix Ra = Ta.rotation(), Rb = Tb.rotation();
+  for (int i = 0; i < Ra.rows(); ++i)
+  {
+    for (int j = 0; j < Ra.cols(); ++j)
+    {
+      EXPECT_NEAR(Ra(i, j), Rb(i, j), TOLERANCE);
+    }
+  }
+
+  Vector pa = Ta.translation(), pb = Tb.translation();
+  EXPECT_NEAR(pa[0], pb[0], TOLERANCE);
+  EXPECT_NEAR(pa[1], pb[1], TOLERANCE);
+  EXPECT_NEAR(pa[2], pb[2], TOLERANCE);
+}
+
+TEST(kuka_kr6, forward_kinematics)
+{
+  const auto kuka = opw_kinematics::makeKukaKR6_R700_sixx<float>();
+
+  std::vector<float> joint_values = {0.2, 0.2, 0.2, 0.2, 0.2, 0.2};
+  Eigen::Affine3f forward_pose = opw_kinematics::forward(kuka, &joint_values[0]);
+
+  // Compare with copied results from forward kinematics using MoveIt!
+  Eigen::Affine3f actual_pose;
+  actual_pose.matrix()  << -0.5965795, 0.000371195,   0.8025539, 0,
+     -0.2724458,   0.9405218,   -0.202958, 0,
+     -0.7548948,  -0.3397331,  -0.5609949, 0,
+      0        ,   0        ,   0        , 1;
+  actual_pose.translation() << 0.7341169, -0.1520347, 0.182639;
+
+  comparePoses(forward_pose, actual_pose);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Thank you for writing this package!

The sign convention for the joints in this package can differ from the one used for an industrial robot. I added this to the robot parameters.
I added it as a `short int sign_corrections[6]`  but a `bool` would be smaller. I thought it was easier to add the sign correction as an int in the calculations. And since you normally have only one set of parameters, the memory penalty seemed less important.

In addition, I updated the io function to also print these new parameters.

Feel free to suggest better solutions, names, ...
This new feature is used by this [moveit plugin](https://github.com/JeroenDM/moveit_opw_kinematics_plugin).

**Note:** I used git cherry-pick to have a branch without the commits from [another pull request](https://github.com/Jmeyer1292/opw_kinematics/pull/2). As they are independent I hope this does not create merge problems...