### PR TITLE
Floating Point Casts

### DIFF
--- a/include/opw_kinematics/opw_kinematics.h
+++ b/include/opw_kinematics/opw_kinematics.h
@@ -29,7 +29,7 @@ using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
  *            configuraton each time.
  */
 template <typename T>
-void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out);
+void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out) noexcept;
 
 /**
  * @brief Computes the tool pose of the robot described by @e when said robot
@@ -39,7 +39,7 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out);
  * @return The flange pose.
  */
 template <typename T>
-Transform<T> forward(const Parameters<T>& p, const T* qs);
+Transform<T> forward(const Parameters<T>& p, const T* qs) noexcept;
 
 #include "opw_kinematics/opw_kinematics_impl.h"
 

--- a/include/opw_kinematics/opw_kinematics_impl.h
+++ b/include/opw_kinematics/opw_kinematics_impl.h
@@ -2,7 +2,7 @@
 #define OPW_KINEMATICS_IMPL_H
 
 template <typename T>
-void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
+void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out) noexcept
 {
   using Vector = Eigen::Matrix<T, 3, 1>;
 
@@ -13,16 +13,16 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
   T nx1 = std::sqrt(c.x() * c.x() + c.y() * c.y() - params.b * params.b) - params.a1;
 
   // Compute theta1_i, theta1_ii
-  T tmp1 = atan2(c.y(), c.x());
-  T tmp2 = atan2(params.b, nx1 + params.a1);
+  T tmp1 = std::atan2(c.y(), c.x());
+  T tmp2 = std::atan2(params.b, nx1 + params.a1);
   T theta1_i = tmp1 - tmp2;
-  T theta1_ii = tmp1 + tmp2 - M_PI;
+  T theta1_ii = tmp1 + tmp2 - T(M_PI);
 
   // theta2 i through iv
   T tmp3 = (c.z() - params.c1);
   T s1_2 = nx1 * nx1 + tmp3 * tmp3;
 
-  T tmp4 = nx1 + 2.0 * params.a1;
+  T tmp4 = nx1 + T(2.0) * params.a1;
   T s2_2 = tmp4 * tmp4 + tmp3 * tmp3;
   T kappa_2 = params.a2 * params.a2 + params.c3 * params.c3;
 
@@ -32,26 +32,26 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
 
   T s1 = std::sqrt(s1_2);
   T s2 = std::sqrt(s2_2);
-  T theta2_i = -std::acos(tmp5 / (2.0 * s1 * params.c2)) +
-                    atan2(nx1, c.z() - params.c1);
-  T theta2_ii = std::acos(tmp5 / (2.0 * s1 * params.c2)) +
-                     atan2(nx1, c.z() - params.c1);
+  T theta2_i = -std::acos(tmp5 / (T(2.0) * s1 * params.c2)) +
+                    std::atan2(nx1, c.z() - params.c1);
+  T theta2_ii = std::acos(tmp5 / (T(2.0) * s1 * params.c2)) +
+                     std::atan2(nx1, c.z() - params.c1);
 
   T tmp6 = s2_2 + c2_2 - kappa_2;
 
-  T theta2_iii = -std::acos(tmp6 / (2.0 * s2 * params.c2)) - atan2(nx1 + 2.0 * params.a1, c.z() - params.c1);
-  T theta2_iv = std::acos(tmp6 / (2.0 * s2 * params.c2)) - atan2(nx1 + 2.0 * params.a1, c.z() - params.c1);
+  T theta2_iii = -std::acos(tmp6 / (T(2.0) * s2 * params.c2)) - std::atan2(nx1 + T(2.0) * params.a1, c.z() - params.c1);
+  T theta2_iv = std::acos(tmp6 / (T(2.0) * s2 * params.c2)) - std::atan2(nx1 + T(2.0) * params.a1, c.z() - params.c1);
 
   // theta3
   T tmp7 = s1_2 - c2_2 - kappa_2;
   T tmp8 = s2_2 - c2_2 - kappa_2;
-  T tmp9 = 2 * params.c2 * std::sqrt(kappa_2);
-  T theta3_i = std::acos(tmp7 / tmp9) - atan2(params.a2, params.c3);
+  T tmp9 = T(2) * params.c2 * std::sqrt(kappa_2);
+  T theta3_i = std::acos(tmp7 / tmp9) - std::atan2(params.a2, params.c3);
 
-  T theta3_ii = -std::acos(tmp7 / tmp9) - atan2(params.a2, params.c3);
+  T theta3_ii = -std::acos(tmp7 / tmp9) - std::atan2(params.a2, params.c3);
 
-  T theta3_iii = std::acos(tmp8 / tmp9) - atan2(params.a2, params.c3);
-  T theta3_iv = -std::acos(tmp8 / tmp9) - atan2(params.a2, params.c3);
+  T theta3_iii = std::acos(tmp8 / tmp9) - std::atan2(params.a2, params.c3);
+  T theta3_iv = -std::acos(tmp8 / tmp9) - std::atan2(params.a2, params.c3);
 
   // Now for the orientation part...
   T s23[4];
@@ -85,49 +85,49 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
   m[2] = matrix(0,2) * s23[2] * cos1[2] + matrix(1,2) * s23[2] * sin1[2] + matrix(2,2) * c23[2];
   m[3] = matrix(0,2) * s23[3] * cos1[3] + matrix(1,2) * s23[3] * sin1[3] + matrix(2,2) * c23[3];
 
-  T theta4_i = atan2(matrix(1,2) * cos1[0] - matrix(0,2) * sin1[0],
+  T theta4_i = std::atan2(matrix(1,2) * cos1[0] - matrix(0,2) * sin1[0],
                    matrix(0,2) * c23[0] * cos1[0] + matrix(1,2) * c23[0] * sin1[0] - matrix(2,2) * s23[0]);
 
-  T theta4_ii = atan2(matrix(1,2) * cos1[1] - matrix(0,2) * sin1[1],
+  T theta4_ii = std::atan2(matrix(1,2) * cos1[1] - matrix(0,2) * sin1[1],
                    matrix(0,2) * c23[1] * cos1[1] + matrix(1,2) * c23[1] * sin1[1] - matrix(2,2) * s23[1]);
 
-  T theta4_iii = atan2(matrix(1,2) * cos1[2] - matrix(0,2) * sin1[2],
+  T theta4_iii = std::atan2(matrix(1,2) * cos1[2] - matrix(0,2) * sin1[2],
                    matrix(0,2) * c23[2] * cos1[2] + matrix(1,2) * c23[2] * sin1[2] - matrix(2,2) * s23[2]);
 
-  T theta4_iv = atan2(matrix(1,2) * cos1[3] - matrix(0,2) * sin1[3],
+  T theta4_iv = std::atan2(matrix(1,2) * cos1[3] - matrix(0,2) * sin1[3],
                    matrix(0,2) * c23[3] * cos1[3] + matrix(1,2) * c23[3] * sin1[3] - matrix(2,2) * s23[3]);
 
-  T theta4_v = theta4_i + M_PI;
-  T theta4_vi = theta4_ii + M_PI;
-  T theta4_vii = theta4_iii + M_PI;
-  T theta4_viii = theta4_iv + M_PI;
+  T theta4_v = theta4_i + T(M_PI);
+  T theta4_vi = theta4_ii + T(M_PI);
+  T theta4_vii = theta4_iii + T(M_PI);
+  T theta4_viii = theta4_iv + T(M_PI);
 
-  T theta5_i = atan2(sqrt(1 - m[0] * m[0]), m[0]);
-  T theta5_ii = atan2(sqrt(1 - m[1] * m[1]), m[1]);
-  T theta5_iii = atan2(sqrt(1 - m[2] * m[2]), m[2]);
-  T theta5_iv = atan2(sqrt(1 - m[3] * m[3]), m[3]);
+  T theta5_i = std::atan2(sqrt(1 - m[0] * m[0]), m[0]);
+  T theta5_ii = std::atan2(sqrt(1 - m[1] * m[1]), m[1]);
+  T theta5_iii = std::atan2(sqrt(1 - m[2] * m[2]), m[2]);
+  T theta5_iv = std::atan2(sqrt(1 - m[3] * m[3]), m[3]);
 
   T theta5_v = -theta5_i;
   T theta5_vi = -theta5_ii;
   T theta5_vii = -theta5_iii;
   T theta5_viii = -theta5_iv;
 
-  T theta6_i = atan2(matrix(0,1) * s23[0] * cos1[0] + matrix(1,1) * s23[0] * sin1[0] + matrix(2,1) * c23[0],
+  T theta6_i = std::atan2(matrix(0,1) * s23[0] * cos1[0] + matrix(1,1) * s23[0] * sin1[0] + matrix(2,1) * c23[0],
                           -matrix(0,0) * s23[0] * cos1[0] - matrix(1, 0) * s23[0] * sin1[0] - matrix(2,0) * c23[0]);
 
-  T theta6_ii = atan2(matrix(0,1) * s23[1] * cos1[1] + matrix(1,1) * s23[1] * sin1[1] + matrix(2,1) * c23[1],
+  T theta6_ii = std::atan2(matrix(0,1) * s23[1] * cos1[1] + matrix(1,1) * s23[1] * sin1[1] + matrix(2,1) * c23[1],
                           -matrix(0,0) * s23[1] * cos1[1] - matrix(1, 0) * s23[1] * sin1[1] - matrix(2,0) * c23[1]);
 
-  T theta6_iii = atan2(matrix(0,1) * s23[2] * cos1[2] + matrix(1,1) * s23[2] * sin1[2] + matrix(2,1) * c23[2],
+  T theta6_iii = std::atan2(matrix(0,1) * s23[2] * cos1[2] + matrix(1,1) * s23[2] * sin1[2] + matrix(2,1) * c23[2],
                           -matrix(0,0) * s23[2] * cos1[2] - matrix(1, 0) * s23[2] * sin1[2] - matrix(2,0) * c23[2]);
 
-  T theta6_iv = atan2(matrix(0,1) * s23[3] * cos1[3] + matrix(1,1) * s23[3] * sin1[3] + matrix(2,1) * c23[3],
+  T theta6_iv = std::atan2(matrix(0,1) * s23[3] * cos1[3] + matrix(1,1) * s23[3] * sin1[3] + matrix(2,1) * c23[3],
                           -matrix(0,0) * s23[3] * cos1[3] - matrix(1, 0) * s23[3] * sin1[3] - matrix(2,0) * c23[3]);
 
-  T theta6_v = theta6_i - M_PI;
-  T theta6_vi = theta6_ii - M_PI;
-  T theta6_vii = theta6_iii - M_PI;
-  T theta6_viii = theta6_iv - M_PI;
+  T theta6_v = theta6_i - T(M_PI);
+  T theta6_vi = theta6_ii - T(M_PI);
+  T theta6_vii = theta6_iii - T(M_PI);
+  T theta6_viii = theta6_iv - T(M_PI);
 
   out[6 * 0 + 0] = (theta1_i + params.offsets[0]) * params.sign_corrections[0];
   out[6 * 0 + 1] = (theta2_i + params.offsets[1]) * params.sign_corrections[1];
@@ -187,7 +187,7 @@ void inverse(const Parameters<T>& params, const Transform<T>& pose, T* out)
 }
 
 template <typename T>
-Transform<T> forward(const Parameters<T>& p, const T* qs)
+Transform<T> forward(const Parameters<T>& p, const T* qs) noexcept
 {
   using Matrix = Eigen::Matrix<T, 3, 3>;
   using Vector = Eigen::Matrix<T, 3, 1>;
@@ -200,30 +200,30 @@ Transform<T> forward(const Parameters<T>& p, const T* qs)
   q[4] = qs[4] * p.sign_corrections[4] - p.offsets[4];
   q[5] = qs[5] * p.sign_corrections[5] - p.offsets[5];
 
-  T psi3 = atan2(p.a2, p.c3);
-  T k = sqrt(p.a2 * p.a2 + p.c3 * p.c3);
+  T psi3 = std::atan2(p.a2, p.c3);
+  T k = std::sqrt(p.a2 * p.a2 + p.c3 * p.c3);
 
-  T cx1 = p.c2 * sin(q[1]) + k * sin(q[1] + q[2] + psi3) + p.a1;
+  T cx1 = p.c2 * std::sin(q[1]) + k * std::sin(q[1] + q[2] + psi3) + p.a1;
   T cy1 = p.b;
-  T cz1 = p.c2 * cos(q[1]) + k * cos(q[1] + q[2] + psi3);
+  T cz1 = p.c2 * std::cos(q[1]) + k * std::cos(q[1] + q[2] + psi3);
 
-  T cx0 = cx1 * cos(q[0]) - cy1 * sin(q[0]);
-  T cy0 = cx1 * sin(q[0]) + cy1 * cos(q[0]);
+  T cx0 = cx1 * std::cos(q[0]) - cy1 * std::sin(q[0]);
+  T cy0 = cx1 * std::sin(q[0]) + cy1 * std::cos(q[0]);
   T cz0 = cz1 + p.c1;
 
-  T s1 = sin(q[0]);
-  T s2 = sin(q[1]);
-  T s3 = sin(q[2]);
-  T s4 = sin(q[3]);
-  T s5 = sin(q[4]);
-  T s6 = sin(q[5]);
+  T s1 = std::sin(q[0]);
+  T s2 = std::sin(q[1]);
+  T s3 = std::sin(q[2]);
+  T s4 = std::sin(q[3]);
+  T s5 = std::sin(q[4]);
+  T s6 = std::sin(q[5]);
 
-  T c1 = cos(q[0]);
-  T c2 = cos(q[1]);
-  T c3 = cos(q[2]);
-  T c4 = cos(q[3]);
-  T c5 = cos(q[4]);
-  T c6 = cos(q[5]);
+  T c1 = std::cos(q[0]);
+  T c2 = std::cos(q[1]);
+  T c3 = std::cos(q[2]);
+  T c4 = std::cos(q[3]);
+  T c5 = std::cos(q[4]);
+  T c6 = std::cos(q[5]);
 
   Matrix r_0c;
   r_0c(0,0) = c1 * c2 * c3- c1 * s2 * s3;

--- a/test/fk_ik_tests.cpp
+++ b/test/fk_ik_tests.cpp
@@ -17,7 +17,7 @@ struct TestTolerance;
 
 template<>
 struct TestTolerance<float> {
-  static constexpr float TOLERANCE = 1e-4f;
+  static constexpr float TOLERANCE = 5e-4f;
   static constexpr const char* const NAME = "float";
 };
 


### PR DESCRIPTION
Builds on #4 

 - Adds noexcept to the FK/IK calls (probably unneeded)
 - Converts all of the `cos` (and the like) to `std::cos` which have overloads for float versus double
 - Casts all literals to floating point type T, e.g. `2.0` -> `T(2.0)`