### PR TITLE
Affine -> Isometry

### DIFF
--- a/include/opw_kinematics/opw_kinematics.h
+++ b/include/opw_kinematics/opw_kinematics.h
@@ -8,11 +8,11 @@ namespace opw_kinematics
 {
 
 /**
- * Typedef equivalent to Eigen::Affine3d for T = double and Eigen::Affine3f for
+ * Typedef equivalent to Eigen::Isometry3d for T = double and Eigen::Isometry3f for
  * T = float.
  */
 template <typename T>
-using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
+using Transform = Eigen::Transform<T, 3, Eigen::Isometry>;
 
 /**
  * @brief Computes up to 8 kinematically unique joint solutions that put the tool

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -20,7 +20,7 @@ int main()
 {
   const auto abb2400 = opw_kinematics::makeIrb2400_10<double>();
 
-  Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  auto pose = opw_kinematics::Transform<double>::Identity();
   pose.translation() = Eigen::Vector3d(0.7, 0.2, 0);
 
   std::array<double, 6 * 8> sols;

--- a/test/abb2400_ikfast_tests.cpp
+++ b/test/abb2400_ikfast_tests.cpp
@@ -4,6 +4,8 @@
 #include "opw_kinematics/opw_kinematics.h"
 #include "opw_kinematics/opw_parameters_examples.h"
 
+using Transform = opw_kinematics::Transform<double>;
+
 struct PoseGenerator
 {
   PoseGenerator()
@@ -11,13 +13,13 @@ struct PoseGenerator
     index = 0;
   }
 
-  Eigen::Affine3d operator()()
+  Transform operator()()
   {
     const static int width = 100;
     int y = index % width;
     int z = index / width;
 
-    Eigen::Affine3d p = Eigen::Affine3d::Identity();
+    Transform p = Transform::Identity();
     p.translation() = Eigen::Vector3d(0.75, y * 0.01 - 0.5, 0.5 + z * 0.01);
 
     index++;
@@ -28,7 +30,7 @@ struct PoseGenerator
   int index;
 };
 
-void solveIKFast(const Eigen::Affine3d& p, ikfast::IkSolutionList<double>& sols)
+void solveIKFast(const Transform& p, ikfast::IkSolutionList<double>& sols)
 {
   double eetrans[3];
   double eerot[9];
@@ -49,7 +51,7 @@ void solveIKFast(const Eigen::Affine3d& p, ikfast::IkSolutionList<double>& sols)
   ComputeIk(eetrans, eerot, pfree, sols);
 }
 
-void solveOPW(const opw_kinematics::Parameters<double>& param, const Eigen::Affine3d& p,
+void solveOPW(const opw_kinematics::Parameters<double>& param, const Transform& p,
               std::array<double, 6 * 8>& sols)
 {
   opw_kinematics::inverse(param, p, sols.data());
@@ -194,7 +196,7 @@ TEST(ikfast_to_opw, similar_solutions)
 
   for (int i = 0; i < 40000; ++i)
   {
-    Eigen::Affine3d p = gen();
+    Transform p = gen();
 
     // Solve with IKFast
     ikfast::IkSolutionList<double> ikf_sols;

--- a/test/sign_corrections_tests.cpp
+++ b/test/sign_corrections_tests.cpp
@@ -8,10 +8,9 @@
 
 const double TOLERANCE = 1e-5; // absolute tolerance for EXPECT_NEAR checks
 
-template <typename T>
-using Transform = Eigen::Transform<T, 3, Eigen::Affine>;
+using opw_kinematics::Transform;
 
-/** @brief Compare every element of two eigen affine3 poses.
+/** @brief Compare every element of two eigen Isometry3 poses.
  */
 template <typename T>
 void comparePoses(const Transform<T> & Ta, const Transform<T> & Tb)
@@ -39,10 +38,10 @@ TEST(kuka_kr6, forward_kinematics)
   const auto kuka = opw_kinematics::makeKukaKR6_R700_sixx<float>();
 
   std::vector<float> joint_values = {0.2f, 0.2f, 0.2f, 0.2f, 0.2f, 0.2f};
-  Eigen::Affine3f forward_pose = opw_kinematics::forward(kuka, &joint_values[0]);
+  Transform<float> forward_pose = opw_kinematics::forward(kuka, &joint_values[0]);
 
   // Compare with copied results from forward kinematics using MoveIt!
-  Eigen::Affine3f actual_pose;
+  Transform<float> actual_pose;
   actual_pose.matrix()  << -0.5965795, 0.000371195,   0.8025539, 0,
      -0.2724458,   0.9405218,   -0.202958, 0,
      -0.7548948,  -0.3397331,  -0.5609949, 0,
@@ -60,12 +59,12 @@ TEST(kuka_kr6, inverse_kinematics)
   const auto kuka = opw_kinematics::makeKukaKR6_R700_sixx<float>();
 
   std::vector<float> joint_values = {0.2f, 0.2f, 0.2f, 0.2f, 0.2f, 0.2f};
-  Eigen::Affine3f forward_pose = opw_kinematics::forward(kuka, &joint_values[0]);
+  Transform<float> forward_pose = opw_kinematics::forward(kuka, &joint_values[0]);
 
   std::array<float, 6 * 8> sols;
   opw_kinematics::inverse(kuka, forward_pose, sols.data());
 
-  Eigen::Affine3f pose;
+  Transform<float> pose;
   for (int i = 0; i < 8; ++i)
   {
     if (opw_kinematics::isValid(&sols[6 * i]))


### PR DESCRIPTION
I fairly recently learned that the ubiquitous use of Affine3d in code related to MoveIt is a bit of a mistake. We'd prefer to use `Isometry` which covers only rigid body transforms.

This makes the change for this library which is young enough to make switches. I welcome thoughts though.

The use of Eigen at all is really not needed for this library. Maybe we should make a transform matrix wrapper? One motivation would be using this library in code on a GPU (though CUDA for instance). I don't know if Eigen works there. 