### PR TITLE
Fix printing of joint sign corrections

### DIFF
--- a/include/opw_kinematics/opw_io.h
+++ b/include/opw_kinematics/opw_io.h
@@ -23,7 +23,7 @@ std::ostream& operator<<(std::ostream& os, const Parameters<T>& params)
   os << "]\nSign_corrections = [";
   for (std::size_t i = 0; i < 6; ++i)
   {
-    os << params.sign_corrections[i] << " ";
+    os << static_cast<int>(params.sign_corrections[i]) << " ";
   }
   os << "]";
   return os;


### PR DESCRIPTION
Print the sign correction as `-1` or `1` instead of the raw character.