### PR TITLE
Add travis based on industrial_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_DISTRO=melodic   # ROS distro to test for
     - ROS_REPO=ros         # ROS binary repository [ros | ros-shadow-fixed]
     - TEST_BLACKLIST=      # list packages, for which to skip the unittests
-    - WARNINGS_OK=false    # Don't accept warnings [true | false]
+    - WARNINGS_OK=true    # Don't accept warnings [true | false]
   matrix:  # define various jobs
   #- TEST=clang-format    # check code formatting for compliance to .clang-format rules
   #- TEST=clang-tidy-fix  # perform static code analysis and compliance check against .clang-tidy rules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,24 @@
-# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
 sudo: required
 dist: trusty
-services:
-  - docker
-language: cpp
-compiler: gcc
-cache: ccache
+language: generic
 
-notifications:
-  email:
-    recipients:
-      # - user@email.com
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true
+
 env:
-  global: # default values that are common to all configurations (can be overriden below)
-    - ROS_DISTRO=melodic   # ROS distro to test for
-    - ROS_REPO=ros         # ROS binary repository [ros | ros-shadow-fixed]
-    - TEST_BLACKLIST=      # list packages, for which to skip the unittests
-    - WARNINGS_OK=true    # Don't accept warnings [true | false]
-  matrix:  # define various jobs
-  #- TEST=clang-format    # check code formatting for compliance to .clang-format rules
-  #- TEST=clang-tidy-fix  # perform static code analysis and compliance check against .clang-tidy rules
-    - TEST=catkin_lint     # perform catkin_lint checks
-    # pull in packages from a local .rosinstall file
-  #  - UPSTREAM_WORKSPACE=moveit.rosinstall
-    # pull in packages from a remote .rosinstall file and run for a non-default ROS_DISTRO
-   #  - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
-      ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed
+  global:
+    - CCACHE_DIR=$HOME/.ccache
+    - ROS_REPO=ros
+  matrix:
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
 
-matrix:
-  include: # Add a separate config to the matrix, using clang as compiler
-    - env: TEST=clang-tidy-check  # run static code analysis, but don't check for available auto-fixes
-      compiler: clang
-  allow_failures:
-    - env: ROS_DISTRO=kinetic  ROS_REPO=ros  #UPSTREAM_WORKSPACE=https://github.com/ros-planning/moveit#$ROS_DISTRO-devel
-
-before_script:
-  # Clone the moveit_ci repository into Travis' workspace
-  - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+install:
+  - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
 
 script:
-  # Run the test script
-  - .moveit_ci/travis.sh
+  - .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
+sudo: required
+dist: trusty
+services:
+  - docker
+language: cpp
+compiler: gcc
+cache: ccache
+
+notifications:
+  email:
+    recipients:
+      # - user@email.com
+env:
+  global: # default values that are common to all configurations (can be overriden below)
+    - ROS_DISTRO=melodic   # ROS distro to test for
+    - ROS_REPO=ros         # ROS binary repository [ros | ros-shadow-fixed]
+    - TEST_BLACKLIST=      # list packages, for which to skip the unittests
+    - WARNINGS_OK=false    # Don't accept warnings [true | false]
+  matrix:  # define various jobs
+  #- TEST=clang-format    # check code formatting for compliance to .clang-format rules
+  #- TEST=clang-tidy-fix  # perform static code analysis and compliance check against .clang-tidy rules
+    - TEST=catkin_lint     # perform catkin_lint checks
+    # pull in packages from a local .rosinstall file
+  #  - UPSTREAM_WORKSPACE=moveit.rosinstall
+    # pull in packages from a remote .rosinstall file and run for a non-default ROS_DISTRO
+   #  - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
+      ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed
+
+matrix:
+  include: # Add a separate config to the matrix, using clang as compiler
+    - env: TEST=clang-tidy-check  # run static code analysis, but don't check for available auto-fixes
+      compiler: clang
+  allow_failures:
+    - env: ROS_DISTRO=kinetic  ROS_REPO=ros  #UPSTREAM_WORKSPACE=https://github.com/ros-planning/moveit#$ROS_DISTRO-devel
+
+before_script:
+  # Clone the moveit_ci repository into Travis' workspace
+  - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+
+script:
+  # Run the test script
+  - .moveit_ci/travis.sh

--- a/include/opw_kinematics/opw_kinematics_impl.h
+++ b/include/opw_kinematics/opw_kinematics_impl.h
@@ -253,7 +253,9 @@ Transform<T> forward(const Parameters<T>& p, const T* qs) noexcept
 
   Matrix r_oe = r_0c * r_ce;
 
-  auto u = Vector(cx0, cy0, cz0) + p.c4 * r_oe * Vector::UnitZ();
+  //Note: do not use auto here, leads to lazy evalutation which
+  // seems to be buggy on at least some setups and uses uninitialized data
+  Vector u = Vector(cx0, cy0, cz0) + p.c4 * r_oe * Vector::UnitZ();
 
   Transform<T> i;
   i.translation() = u;

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>eigen</depend>
 
   <export>
   </export>


### PR DESCRIPTION
Surprisingly on this setup all tests succeed while they all fail on our internal CI or on my local pc ...

This could be extended to do more advanced stuff like clang-format, clang-tidy etc