### PR TITLE
Make opw_kinematics a pure cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,68 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(opw_kinematics)
-
-add_compile_options(-std=c++11 -Wall -Wextra)
-
-find_package(catkin REQUIRED)
+cmake_minimum_required(VERSION 3.5.0)
+project(opw_kinematics VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED)
-if(NOT EIGEN3_INCLUDE_DIRS)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
-endif()
 
-catkin_package(
-  INCLUDE_DIRS include
-  DEPENDS EIGEN3
-)
+# Create interface target
+add_library(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE)
+target_compile_options(${PROJECT_NAME} INTERFACE -Wall -Wextra)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+target_include_directories(${PROJECT_NAME} INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
+    $<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>)
 
-###########
-## Build ##
-###########
-
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-)
-
+# Create test executable
 add_executable(${PROJECT_NAME}_node src/test.cpp)
-
 set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(${PROJECT_NAME}_node
- ${catkin_LIBRARIES}
-)
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
 
 #############
 ## Install ##
 #############
+list (APPEND PACKAGE_LIBRARIES ${PROJECT_NAME})
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+# Mark executables and/or libraries for installation
+install(TARGETS ${PACKAGE_LIBRARIES} EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
+install(EXPORT ${PROJECT_NAME}-targets DESTINATION lib/cmake/${PROJECT_NAME})
+
+# Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.hxx"
   PATTERN ".svn" EXCLUDE
-)
+ )
+
+install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+
+# Create cmake config files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+  VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+  DESTINATION lib/cmake/${PROJECT_NAME})
+
+export(EXPORT ${PROJECT_NAME}-targets FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake)
 
 #############
 ## Testing ##
 #############
+option(ENABLE_TESTS "Enable tests" OFF)
+if (${ENABLE_TESTS})
+  enable_testing()
+  add_custom_target(run_tests ALL
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION> -V)
 
-if(CATKIN_ENABLE_TESTING)
-
-  # Compares the opw solutions with an ikfast generated for the same robot model
-  catkin_add_gtest(${PROJECT_NAME}-test-2400-ikfast
-    test/abb2400_ikfast_tests.cpp
-    test/abb_irb2400_manipulator_ikfast_solver.cpp
-  )
-  target_compile_definitions(${PROJECT_NAME}-test-2400-ikfast PUBLIC -DIKFAST_NO_MAIN
-    -DIKFAST_CLIBRARY -DIKFAST_HAS_LIBRARY)
-
-  # Compares a known solution for a robot with varying joint "signs"
-  catkin_add_gtest(${PROJECT_NAME}-test-sign-corrections test/sign_corrections_tests.cpp)
-
-  # Runs tests that iteratively solve FK then IK then confirm the new FK matches
-  # Also contains some throughput tests
-  catkin_add_gtest(${PROJECT_NAME}-fk-ik test/fk_ik_tests.cpp)
-
-endif() # end catkin_enable_testing
+  add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,29 @@
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(opw_kinematics VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED)
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
+list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_std_11 CXX_FEATURE_FOUND)
 
 # Create interface target
 add_library(${PROJECT_NAME} INTERFACE)
 target_link_libraries(${PROJECT_NAME} INTERFACE)
 target_compile_options(${PROJECT_NAME} INTERFACE -Wall -Wextra)
-target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+if(CXX_FEATURE_FOUND EQUAL "-1")
+    set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES)
+else()
+    target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+endif()
+
 target_include_directories(${PROJECT_NAME} INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE
-    $<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>)
+    ${EIGEN3_INCLUDE_DIRS})
 
 # Create test executable
 add_executable(${PROJECT_NAME}_node src/test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.8.0)
 project(opw_kinematics VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED)

--- a/cmake/opw_kinematics-config.cmake.in
+++ b/cmake/opw_kinematics-config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+set(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIBRARIES@")
+
+include(CMakeFindDependencyMacro)
+find_dependency(Eigen3)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>eigen</depend>
+  <test_depend>gtest</test_depend>
 
   <export>
+    <build_type>cmake</build_type>
   </export>
 </package>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+find_package(GTest REQUIRED)
+
+# Compares the opw solutions with an ikfast generated for the same robot model
+add_executable(${PROJECT_NAME}-test-2400-ikfast abb2400_ikfast_tests.cpp abb_irb2400_manipulator_ikfast_solver.cpp)
+target_link_libraries(${PROJECT_NAME}-test-2400-ikfast ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
+target_compile_definitions(${PROJECT_NAME}-test-2400-ikfast PUBLIC -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -DIKFAST_HAS_LIBRARY)
+target_compile_features(${PROJECT_NAME}-test-2400-ikfast PRIVATE cxx_std_11)
+target_include_directories(${PROJECT_NAME}-test-2400-ikfast PRIVATE ${GTEST_INCLUDE_DIRS})
+gtest_discover_tests(${PROJECT_NAME}-test-2400-ikfast)
+add_dependencies(run_tests ${PROJECT_NAME}-test-2400-ikfast)
+
+# Compares a known solution for a robot with varying joint "signs"
+add_executable(${PROJECT_NAME}-test-sign-corrections sign_corrections_tests.cpp)
+target_link_libraries(${PROJECT_NAME}-test-sign-corrections ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME}-test-sign-corrections PRIVATE cxx_std_11)
+target_include_directories(${PROJECT_NAME}-test-sign-corrections PRIVATE ${GTEST_INCLUDE_DIRS})
+gtest_discover_tests(${PROJECT_NAME}-test-sign-corrections)
+add_dependencies(run_tests ${PROJECT_NAME}-test-sign-corrections)
+
+# Runs tests that iteratively solve FK then IK then confirm the new FK matches
+# Also contains some throughput tests
+add_executable(${PROJECT_NAME}-fk-ik fk_ik_tests.cpp)
+target_link_libraries(${PROJECT_NAME}-fk-ik ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME}-fk-ik PRIVATE cxx_std_11)
+target_include_directories(${PROJECT_NAME}-fk-ik PRIVATE ${GTEST_INCLUDE_DIRS})
+gtest_discover_tests(${PROJECT_NAME}-fk-ik)
+add_dependencies(run_tests ${PROJECT_NAME}-fk-ik)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,20 @@
 find_package(GTest REQUIRED)
 
+macro(opw_add_test name)
+    if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+        gtest_add_tests(${name})
+    else()
+        gtest_discover_tests(${name})
+    endif()
+endmacro()
+
 # Compares the opw solutions with an ikfast generated for the same robot model
 add_executable(${PROJECT_NAME}-test-2400-ikfast abb2400_ikfast_tests.cpp abb_irb2400_manipulator_ikfast_solver.cpp)
 target_link_libraries(${PROJECT_NAME}-test-2400-ikfast ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
 target_compile_definitions(${PROJECT_NAME}-test-2400-ikfast PUBLIC -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -DIKFAST_HAS_LIBRARY)
 target_compile_features(${PROJECT_NAME}-test-2400-ikfast PRIVATE cxx_std_11)
 target_include_directories(${PROJECT_NAME}-test-2400-ikfast PRIVATE ${GTEST_INCLUDE_DIRS})
-gtest_discover_tests(${PROJECT_NAME}-test-2400-ikfast)
+opw_add_test(${PROJECT_NAME}-test-2400-ikfast)
 add_dependencies(run_tests ${PROJECT_NAME}-test-2400-ikfast)
 
 # Compares a known solution for a robot with varying joint "signs"
@@ -14,7 +22,7 @@ add_executable(${PROJECT_NAME}-test-sign-corrections sign_corrections_tests.cpp)
 target_link_libraries(${PROJECT_NAME}-test-sign-corrections ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME}-test-sign-corrections PRIVATE cxx_std_11)
 target_include_directories(${PROJECT_NAME}-test-sign-corrections PRIVATE ${GTEST_INCLUDE_DIRS})
-gtest_discover_tests(${PROJECT_NAME}-test-sign-corrections)
+opw_add_test(${PROJECT_NAME}-test-sign-corrections)
 add_dependencies(run_tests ${PROJECT_NAME}-test-sign-corrections)
 
 # Runs tests that iteratively solve FK then IK then confirm the new FK matches
@@ -23,5 +31,5 @@ add_executable(${PROJECT_NAME}-fk-ik fk_ik_tests.cpp)
 target_link_libraries(${PROJECT_NAME}-fk-ik ${GTEST_BOTH_LIBRARIES} ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME}-fk-ik PRIVATE cxx_std_11)
 target_include_directories(${PROJECT_NAME}-fk-ik PRIVATE ${GTEST_INCLUDE_DIRS})
-gtest_discover_tests(${PROJECT_NAME}-fk-ik)
+opw_add_test(${PROJECT_NAME}-fk-ik)
 add_dependencies(run_tests ${PROJECT_NAME}-fk-ik)


### PR DESCRIPTION
I believe it would be beneficial to make this a pure cmake package since it does not leverage ros directly to allow for it to be leverage by the broader opensource community.