### PR TITLE
Use new source_bat.bash command to set env variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,6 @@ install:
         source source_bat.bash 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
         choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
         choco install ros-melodic-ros_base -y --execution-timeout=0
-        #wget https://gist.githubusercontent.com/Levi-Armstrong/e3bb008e579a99c52eb74235dff6735a/raw/travis_ci_windows.bat
-        #cmd "/C call travis_ci_windows.bat install "        
         source source_bat.bash 'c:\opt\ros\melodic\x64\setup.bat'
         rosdep install --from-paths src --ignore-src -r -y
         /c/opt/vcpkg/vcpkg.exe install jsoncpp:x64-windows
@@ -55,4 +53,4 @@ install:
 
 script:
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then .ci_config/travis.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then catkin_make_isolated -DENABLE_TESTS=ON; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then catkin_make_isolated -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,12 @@ install:
         cd catkin_ws        
         choco uninstall mingw
         wget https://raw.githubusercontent.com/johnwason/source_bat/master/source_bat.bash
-        alias source_bat="source source_bat.bash"
-        source_bat 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
+        source source_bat.bash 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
         choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
         choco install ros-melodic-ros_base -y --execution-timeout=0
         #wget https://gist.githubusercontent.com/Levi-Armstrong/e3bb008e579a99c52eb74235dff6735a/raw/travis_ci_windows.bat
         #cmd "/C call travis_ci_windows.bat install "        
-        source_bat 'c:\opt\ros\melodic\x64\setup.bat'
+        source source_bat.bash 'c:\opt\ros\melodic\x64\setup.bat'
         rosdep install --from-paths src --ignore-src -r -y
         /c/opt/vcpkg/vcpkg.exe install jsoncpp:x64-windows
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,16 @@ install:
         choco uninstall mingw
         choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
         choco install ros-melodic-ros_base -y --execution-timeout=0
-        wget https://gist.githubusercontent.com/Levi-Armstrong/e3bb008e579a99c52eb74235dff6735a/raw/travis_ci_windows.bat
-        cmd "/C call travis_ci_windows.bat install "
+        #wget https://gist.githubusercontent.com/Levi-Armstrong/e3bb008e579a99c52eb74235dff6735a/raw/travis_ci_windows.bat
+        #cmd "/C call travis_ci_windows.bat install "
+        alias source_bat="source source_bat.bash"
+        wget https://raw.githubusercontent.com/johnwason/source_bat/master/source_bat.bash
+        source_bat 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
+        source_bat 'c:\opt\ros\melodic\x64\setup.bat'
+        rosdep install --from-paths src --ignore-src -r -y
+        /c/opt/vcpkg/vcpkg.exe install jsoncpp:x64-windows
     fi
 
 script:
   - if [ "$TRAVIS_OS_NAME" != "windows" ]; then .ci_config/travis.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then cmd "/C call travis_ci_windows.bat build "; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then catkin_make_isolated -DENABLE_TESTS=ON; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,15 @@ install:
         cd ..
         mkdir -p catkin_ws/src
         mv opw_kinematics catkin_ws/src/
-        cd catkin_ws
+        cd catkin_ws        
         choco uninstall mingw
+        wget https://raw.githubusercontent.com/johnwason/source_bat/master/source_bat.bash
+        alias source_bat="source source_bat.bash"
+        source_bat 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
         choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
         choco install ros-melodic-ros_base -y --execution-timeout=0
         #wget https://gist.githubusercontent.com/Levi-Armstrong/e3bb008e579a99c52eb74235dff6735a/raw/travis_ci_windows.bat
-        #cmd "/C call travis_ci_windows.bat install "
-        alias source_bat="source source_bat.bash"
-        wget https://raw.githubusercontent.com/johnwason/source_bat/master/source_bat.bash
-        source_bat 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
+        #cmd "/C call travis_ci_windows.bat install "        
         source_bat 'c:\opt\ros\melodic\x64\setup.bat'
         rosdep install --from-paths src --ignore-src -r -y
         /c/opt/vcpkg/vcpkg.exe install jsoncpp:x64-windows


### PR DESCRIPTION
I created a small script source_bat.bash to read environmental variables in batch files and export them to Git Bash. This allows for commands to be run directly in Git Bash instead of in batch files.