### PR TITLE
Only enable initialize_code_coverage if code coverage is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 opw_variables()
 
 if(NOT MSVC)
-  initialize_code_coverage()
+  initialize_code_coverage(ENABLE ${OPW_ENABLE_CODE_COVERAGE})
   add_code_coverage_all_targets(ENABLE ${OPW_ENABLE_CODE_COVERAGE})
 endif()
 


### PR DESCRIPTION
This is to address issue #54. @gavanderhoorn I believe this should solve the issue; do you agree? I have update ros_industrial_cmake_boilerplate to support disabling/enabling this and created a release.