### PR TITLE
Fix build issues with newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.5.0..3.99)
 
 # Extract package name and version
 find_package(ros_industrial_cmake_boilerplate REQUIRED)
@@ -24,7 +24,7 @@ endif()
 # Create interface target
 add_library(${PROJECT_NAME} INTERFACE)
 target_compile_definitions(${PROJECT_NAME} INTERFACE ${OPW_COMPILE_DEFINITIONS})
-target_link_libraries(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)
 target_cxx_version(${PROJECT_NAME} INTERFACE VERSION ${OPW_CXX_VERSION})
 target_compile_options(${PROJECT_NAME} INTERFACE ${OPW_COMPILE_OPTIONS_PUBLIC})
 target_clang_tidy(${PROJECT_NAME} ENABLE ${OPW_ENABLE_CLANG_TIDY} ARGUMENTS ${OPW_CLANG_TIDY_ARGS})


### PR DESCRIPTION
Two CMake problems are appearing with newer CMake versions:

* CMake versions below 3.10 are no longer supported. This patch adds a range 3.5..3.99 to silence this error. For a simple project like this there is no difference.
* Eigen3 include paths are not being set correctly. This patch adds an interface target_link_library to Eigen3.