### PR TITLE
Remove -mno-avx gcc compiler flag

### DIFF
--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -24,7 +24,7 @@ jobs:
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DOPW_ENABLE_TESTING=ON -DOPW_PACKAGE=ON"
       AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose opw_kinematics --make-args test'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space
         run: |
@@ -42,7 +42,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ${{ env.CI_NAME }}/.ccache
           key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -21,7 +21,7 @@ jobs:
       CLANG_FORMAT_CHECK: file
       CLANG_FORMAT_VERSION: 8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space
         run: |
@@ -39,7 +39,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ${{ env.CI_NAME }}/.ccache
           key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       CI_NAME: CodeCov
       OS_NAME: ubuntu
-      OS_CODE_NAME: bionic
-      ROS_DISTRO: melodic
+      OS_CODE_NAME: focal
+      ROS_DISTRO: noetic
       ROS_REPO: main
       ADDITIONAL_DEBS: curl
       UPSTREAM_WORKSPACE: 'dependencies.rosinstall'
@@ -26,7 +26,7 @@ jobs:
       AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps opw_kinematics --make-args ccov-all
                      && bash <(curl -s https://codecov.io/bash) -t e964c16f-f94e-4caa-8c82-8a142891a19b -s $target_ws/build -f *all-merged.info'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space
         run: |
@@ -44,7 +44,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ${{ env.CI_NAME }}/.ccache
           key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -24,7 +24,7 @@ jobs:
       BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source /root/target_ws/install/setup.bash"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DOPW_ENABLE_TESTING=ON -DOPW_PACKAGE=ON"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Free Disk Space
         run: |
@@ -42,7 +42,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: ${{ env.CI_NAME }}/.ccache
           key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/package_nuget.yml
+++ b/.github/workflows/package_nuget.yml
@@ -17,7 +17,7 @@ jobs:
     name: Windows-2019
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: workspace/src/opw_kinematics
 
@@ -26,7 +26,7 @@ jobs:
         mkdir artifacts
 
     - name: checkout-vcpkg
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: vcpkg
         repository: microsoft/vcpkg
@@ -59,7 +59,7 @@ jobs:
         vcpkg install --triplet x64-windows ${{ env.VCPKG_PKGS }}
 
     - name: configure-msvc
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@v2
       with:
         arch: x64
 

--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -17,12 +17,12 @@ jobs:
     name: Windows-2019
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: workspace/src/opw_kinematics
 
     - name: checkout-vcpkg
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: vcpkg
         repository: microsoft/vcpkg
@@ -55,7 +55,7 @@ jobs:
         vcpkg install --triplet x64-windows ${{ env.VCPKG_PKGS }}
 
     - name: configure-msvc
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@v2
       with:
         arch: x64
 

--- a/cmake/opw_kinematics_macros.cmake
+++ b/cmake/opw_kinematics_macros.cmake
@@ -55,21 +55,6 @@ macro(opw_variables)
           -Wsign-conversion
           -Wno-sign-compare
           -Wnon-virtual-dtor)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(OPW_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(OPW_COMPILE_OPTIONS_PRIVATE
           -Wall
@@ -92,21 +77,6 @@ macro(opw_variables)
           -Werror=sign-conversion
           -Wno-sign-compare
           -Werror=non-virtual-dtor)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(OPW_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(OPW_COMPILE_OPTIONS_PRIVATE
           -Werror=all


### PR DESCRIPTION
The `-mno-avx` gcc compiler flag does not appear to be necessary with modern gcc versions.