### PR TITLE
Fix cmake AppleClang detection

### DIFF
--- a/cmake/opw_kinematics_macros.cmake
+++ b/cmake/opw_kinematics_macros.cmake
@@ -70,7 +70,7 @@ macro(opw_variables)
              "unknown")
         set(OPW_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(OPW_COMPILE_OPTIONS_PRIVATE
           -Wall
           -Wextra
@@ -107,7 +107,7 @@ macro(opw_variables)
              "unknown")
         set(OPW_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(OPW_COMPILE_OPTIONS_PRIVATE
           -Werror=all
           -Werror=extra


### PR DESCRIPTION
This PR fixes cmake AppleClang detection. Updates to use:

```
CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*"
```

to correctly detect the AppleClang compiler.